### PR TITLE
finetune categorizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+.DS_Store
+big-sample-shift-preview-improved.json
+big-sample-shift-preview.json
+ss

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	applyTargetDir string
-	previewFile    string
-	dryRun         bool
+	applyTargetDir            string
+	previewFile               string
+	dryRun                    bool
+	applyNormalizeFilenames   bool
 )
 
 var applyCmd = &cobra.Command{
@@ -69,7 +70,7 @@ or use a previously generated preview file.`,
 				os.Exit(1)
 			}
 
-			categorized = categorizer.CategorizeBatch(samples, applyTargetDir)
+			categorized = categorizer.CategorizeBatch(samples, applyTargetDir, applyNormalizeFilenames)
 		}
 
 		if len(categorized) == 0 {
@@ -149,4 +150,5 @@ func init() {
 	applyCmd.Flags().StringVarP(&applyTargetDir, "target", "t", "", "Target directory for organized samples")
 	applyCmd.Flags().StringVarP(&previewFile, "preview-file", "p", "", "Use a previously saved preview file")
 	applyCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview what would be done without actually copying files")
+	applyCmd.Flags().BoolVar(&applyNormalizeFilenames, "normalize", false, "Normalize filenames (lowercase, spaces and underscores to dashes)")
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	targetDir  string
-	outputFile string
+	targetDir          string
+	outputFile         string
+	normalizeFilenames bool
 )
 
 var previewCmd = &cobra.Command{
@@ -52,7 +53,7 @@ This shows where each file will be copied to when you run the apply command.`,
 		}
 
 		// Categorize files
-		categorized := categorizer.CategorizeBatch(samples, targetDir)
+		categorized := categorizer.CategorizeBatch(samples, targetDir, normalizeFilenames)
 
 		// Group by category
 		categoryGroups := make(map[categorizer.Category][]categorizer.CategorizedFile)
@@ -106,4 +107,5 @@ func savePreview(categorized []categorizer.CategorizedFile, filename string) {
 func init() {
 	previewCmd.Flags().StringVarP(&targetDir, "target", "t", "", "Target directory for organized samples (required)")
 	previewCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Save preview to JSON file for later use with apply command")
+	previewCmd.Flags().BoolVar(&normalizeFilenames, "normalize", false, "Normalize filenames (lowercase, spaces and underscores to dashes)")
 }

--- a/internal/categorizer/categorizer.go
+++ b/internal/categorizer/categorizer.go
@@ -2,6 +2,7 @@ package categorizer
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/theclifmeister/sample-shifter/internal/scanner"
@@ -20,19 +21,24 @@ const (
 	CategoryMelodic       Category = "melodic"
 	CategoryLoop          Category = "loops"
 	CategoryOneShot       Category = "oneshots"
+	CategoryAmbiance      Category = "ambiance"
+	CategoryTransition    Category = "transition"
+	CategoryFoley         Category = "foley"
 	CategoryUncategorized Category = "uncategorized"
 )
 
 // CategorizedFile represents a file with its determined category
 type CategorizedFile struct {
-	Sample     scanner.SampleFile
-	Category   Category
-	TargetPath string
+	Sample      scanner.SampleFile
+	Category    Category
+	Subcategory string
+	TargetPath  string
 }
 
 // categoryPriority defines the order in which categories are checked
 // Categories earlier in the list have higher priority
 var categoryPriority = []Category{
+	CategoryOneShot,     // Check one-shots first (shots/hits/stabs)
 	CategoryDrum,
 	CategoryBass,
 	CategoryPercussion,
@@ -40,15 +46,17 @@ var categoryPriority = []Category{
 	CategorySynth,
 	CategoryMelodic,
 	CategoryFX,
+	CategoryTransition,
+	CategoryAmbiance,
+	CategoryFoley,
 	CategoryLoop,
-	CategoryOneShot,
 }
 
 // keywords maps category keywords to categories
 var keywords = map[Category][]string{
 	CategoryDrum: {
-		"kick", "snare", "hihat", "hi-hat", "clap", "tom", "cymbal", "crash", "ride",
-		"drum", "bd", "sd", "hh",
+		"kick", "snare", "hihat", "hi-hat", "hi_hat", "hi hat", "hats", "clap", "tom", "cymbal", "crash", "ride",
+		"drum", "bd", "sd", "hh", "closed hat", "open hat", "hat closed", "hat open",
 	},
 	CategoryBass: {
 		"bass", "sub", "808", "909",
@@ -57,7 +65,7 @@ var keywords = map[Category][]string{
 		"synth", "lead", "pad", "pluck", "saw", "square", "sine",
 	},
 	CategoryVocal: {
-		"vocal", "vox", "voice", "acapella", "choir", "shout", "chant",
+		"vocal", "vox", "voice", "acapella", "choir", "shout", "chant", "adlib",
 	},
 	CategoryFX: {
 		"fx", "sfx", "riser", "downsweep", "whoosh", "impact", "sweep", "noise",
@@ -70,27 +78,439 @@ var keywords = map[Category][]string{
 		"piano", "guitar", "bell", "marimba", "xylophone", "harp", "strings",
 		"violin", "cello", "flute", "horn", "trumpet", "sax", "saxophone",
 		"organ", "keys", "brass", "woodwind", "arpeggio", "arpeggiated", "melody",
+		"oud", "bouzouki", "duduk", "glissentar", "joombush", "mandolin", "mandolino",
+	},
+	CategoryTransition: {
+		"fill", "transition", "build", "buildup", "build-up", "breakdown", "break-down",
+		"downlifter", "stop",
+	},
+	CategoryAmbiance: {
+		"ambiance", "ambient", "atmosphere", "drone", "texture", "atmospheric",
+	},
+	CategoryFoley: {
+		"foley", "bird", "animal", "water", "splash", "scratch", "vinyl", "snap",
+		"whistle", "ocean", "nature", "wind",
 	},
 	CategoryLoop: {
 		"loop", "phrase", "bar", "beat",
 	},
 	CategoryOneShot: {
-		"oneshot", "one-shot", "hit", "stab",
+		"oneshot", "one-shot", "hit", "stab", "shot",
 	},
 }
 
+// subcategoryKeywords maps specific keywords to subcategory folder names
+var subcategoryKeywords = map[Category]map[string]string{
+	CategoryDrum: {
+		// Existing subcategories
+		"kick":  "kick",
+		"bd":    "kick",
+		"snare": "snare",
+		"sd":    "snare",
+		"hihat":       "hihat",
+		"hi-hat":      "hihat",
+		"hi_hat":      "hihat",
+		"hi hat":      "hihat",
+		"hh":          "hihat",
+		"hats":        "hihat",
+		"closed hat":  "hihat",
+		"open hat":    "hihat",
+		"hat closed":  "hihat",
+		"hat open":    "hihat",
+		"clap":   "clap",
+		"tom":    "tom",
+		"toms":   "tom",
+		"cymbal": "cymbal",
+		"crash":  "cymbal",
+		"ride":   "cymbal",
+		// New subcategories
+		"drum fill":       "fill",
+		"drum_fill":       "fill",
+		"drum loop":       "loop",
+		"drum_loop":       "loop",
+		"beat loop":       "loop",
+		"beat_loop":       "loop",
+		"ethnic drum":     "ethnic",
+		"ethnic_drum":     "ethnic",
+		"indian drum":     "ethnic",
+		"indian_drum":     "ethnic",
+		"tribal drum":     "ethnic",
+		"tribal_drum":     "ethnic",
+		"acoustic drum":   "acoustic",
+		"acoustic_drum":   "acoustic",
+		"cinematic drum":  "cinematic",
+		"cinematic_drum":  "cinematic",
+		"cinematic":       "cinematic",
+	},
+	CategoryBass: {
+		// Existing subcategories
+		"sub":      "sub",
+		"subbass":  "sub",
+		"sub-bass": "sub",
+		"sub_bass": "sub",
+		"808": "808",
+		"909": "909",
+		// New subcategories
+		"growl":  "growl",
+		"wobble": "growl",
+		"whomp":  "growl",
+		"freak":  "growl",
+		"bass loop":  "loop",
+		"bass_loop":  "loop",
+		"bassloop":   "loop",
+		"psy":        "psy",
+		"psy bass":   "psy",
+		"psy_bass":   "psy",
+		"psybass":    "psy",
+		"bass pluck":   "pluck",
+		"bass_pluck":   "pluck",
+		"pluck bass":   "pluck",
+		"pluck_bass":   "pluck",
+		"plucked bass": "pluck",
+		"plucked_bass": "pluck",
+	},
+	CategorySynth: {
+		// Existing subcategories
+		"lead":        "lead",
+		"leads":       "lead",
+		"synth lead":  "lead",
+		"synth_lead":  "lead",
+		"pad":         "pad",
+		"pads":        "pad",
+		"synth pad":   "pad",
+		"synth_pad":   "pad",
+		"pluck":        "pluck",
+		"plucks":       "pluck",
+		"plucked":      "pluck",
+		"synth pluck":  "pluck",
+		"synth_pluck":  "pluck",
+		"saw":      "saw",
+		"sawtooth": "saw",
+		"square": "square",
+		"sine":   "sine",
+		// New subcategories
+		"synth loop":  "loop",
+		"synth_loop":  "loop",
+		"synthloop":   "loop",
+		"reverse synth": "reverse",
+		"reverse_synth": "reverse",
+		"reversed":      "reverse",
+		"synth fill":  "fill",
+		"synth_fill":  "fill",
+		"synthfill":   "fill",
+		"arp":         "arp",
+		"arpeggio":    "arp",
+		"arpeggiated": "arp",
+		"blip":  "blip",
+		"beep":  "blip",
+		"bleep": "blip",
+	},
+	CategoryVocal: {
+		"vocal":    "vocal",
+		"vox":      "vox",
+		"voice":    "voice",
+		"acapella": "acapella",
+		"choir":    "choir",
+		"chorus":   "choir",
+		"ensemble": "choir",
+		"shout":    "shout",
+		"yell":     "shout",
+		"scream":   "shout",
+		"chant":    "chant",
+		"chanting": "chant",
+		"adlib":    "adlib",
+		"ad-lib":   "adlib",
+		"ad lib":   "adlib",
+	},
+	CategoryFX: {
+		// Existing subcategories
+		"riser":     "riser",
+		"uplift":    "riser",
+		"risefx":    "riser",
+		"downsweep": "downsweep",
+		"whoosh":    "whoosh",
+		"impact":    "impact",
+		"boom":      "impact",
+		"slam":      "impact",
+		"sweep":     "sweep",
+		"uplifter":  "sweep",
+		"noise":       "noise",
+		"white":       "noise",
+		"white noise": "noise",
+		"pink noise":  "noise",
+		"reverse": "reverse",
+		"rev":     "reverse",
+		// New subcategories
+		"game":       "game",
+		"video game": "game",
+		"psy":        "psy",
+		"psychedelic": "psy",
+		"transformer": "transformer",
+		"robot":       "transformer",
+		"laser":  "laser",
+		"lazer":  "laser",
+		"water":  "water",
+		"splash": "water",
+		"ocean":  "water",
+	},
+	CategoryPercussion: {
+		// Existing subcategories
+		"shaker": "shaker",
+		"shake":  "shaker",
+		"conga":  "conga",
+		"congas": "conga",
+		"bongo":      "bongo",
+		"tambourine": "tambourine",
+		"tamb":       "tambourine",
+		"cowbell":    "cowbell",
+		"cow bell":   "cowbell",
+		// New subcategories
+		"hi perc":           "high",
+		"hi_perc":           "high",
+		"high perc":         "high",
+		"high_perc":         "high",
+		"high percussion":   "high",
+		"high_percussion":   "high",
+		"percussion high":   "high",
+		"percussion_high":   "high",
+		"low perc":          "low",
+		"low_perc":          "low",
+		"low percussion":    "low",
+		"low_percussion":    "low",
+		"percussion low":    "low",
+		"percussion_low":    "low",
+		"mid perc":          "mid",
+		"mid_perc":          "mid",
+		"mid percussion":    "mid",
+		"mid_percussion":    "mid",
+		"percussion mid":    "mid",
+		"percussion_mid":    "mid",
+		"percussion loop":   "loop",
+		"percussion_loop":   "loop",
+		"perc loop":         "loop",
+		"perc_loop":         "loop",
+		"rimshot":           "rimshot",
+		"rim shot":          "rimshot",
+		"rim_shot":          "rimshot",
+		"rim":               "rimshot",
+		"clank":             "clank",
+		"metal perc":        "clank",
+		"metal_perc":        "clank",
+		"metallic":          "clank",
+		"wooden":            "wood",
+		"wood perc":         "wood",
+		"wood_perc":         "wood",
+		"wooden perc":       "wood",
+		"wooden_perc":       "wood",
+		"slap":              "slap",
+		"percussion slap":   "slap",
+		"percussion_slap":   "slap",
+		"knock":             "knock",
+		"percussion knock":  "knock",
+		"percussion_knock":  "knock",
+		"beatbox":           "beatbox",
+		"beat box":          "beatbox",
+		"beat_box":          "beatbox",
+		"ethnic perc":       "ethnic",
+		"ethnic_perc":       "ethnic",
+		"tribal perc":       "ethnic",
+		"tribal_perc":       "ethnic",
+		"african perc":      "ethnic",
+		"african_perc":      "ethnic",
+		"indian perc":       "ethnic",
+		"indian_perc":       "ethnic",
+	},
+	CategoryMelodic: {
+		// Existing subcategories
+		"piano":   "piano",
+		"guitar":  "guitar",
+		"gtr":     "guitar",
+		"acoustic guitar": "guitar",
+		"electric guitar": "guitar",
+		"bell":      "bell",
+		"marimba":   "marimba",
+		"xylophone": "xylophone",
+		"harp":    "harp",
+		"strings": "strings",
+		"string":  "strings",
+		"violin":  "strings",
+		"cello":   "strings",
+		"viola":   "strings",
+		"flute":     "woodwind",
+		"clarinet":  "woodwind",
+		"oboe":      "woodwind",
+		"sax":       "woodwind",
+		"saxophone": "woodwind",
+		"horn":     "brass",
+		"trumpet":  "brass",
+		"trombone": "brass",
+		"organ":    "keys",
+		"keys":     "keys",
+		"keyboard": "keys",
+		"brass":    "brass",
+		"woodwind": "woodwind",
+		// New subcategories
+		"oud":        "oud",
+		"bouzouki":   "bouzouki",
+		"duduk":      "duduk",
+		"glissentar": "glissentar",
+		"joombush":   "joombush",
+		"mandolin":   "mandolin",
+		"mandolino":  "mandolin",
+	},
+	CategoryTransition: {
+		"fill":       "fill",
+		"transition": "transition",
+		"build":      "buildup",
+		"buildup":    "buildup",
+		"build-up":   "buildup",
+		"breakdown":  "breakdown",
+		"break-down": "breakdown",
+		"downlifter": "downlifter",
+		"stop":       "stop",
+	},
+	CategoryAmbiance: {
+		"dark":        "dark",
+		"bright":      "bright",
+		"space":       "space",
+		"nature":      "nature",
+		"industrial":  "industrial",
+	},
+	CategoryFoley: {
+		"bird":      "nature",
+		"animal":    "animal",
+		"water":     "water",
+		"splash":    "water",
+		"ocean":     "water",
+		"scratch":   "vinyl",
+		"vinyl":     "vinyl",
+		"snap":      "human",
+		"whistle":   "human",
+		"wind":      "nature",
+		"mechanical": "mechanical",
+	},
+	CategoryLoop: {
+		"loop":   "loop",
+		"phrase": "phrase",
+		"bar":    "bar",
+		"beat":   "beat",
+	},
+	CategoryOneShot: {
+		// Restructured for instrument-specific subcategories
+		"bass shot":    "bass",
+		"bass_shot":    "bass",
+		"bass stab":    "bass",
+		"bass_stab":    "bass",
+		"bass hit":     "bass",
+		"bass_hit":     "bass",
+		"bassshot":     "bass",
+		"synth shot":   "synth",
+		"synth_shot":   "synth",
+		"synth stab":   "synth",
+		"synth_stab":   "synth",
+		"synthshot":    "synth",
+		"vocal shot":   "vocal",
+		"vocal_shot":   "vocal",
+		"drum hit":     "drum",
+		"drum_hit":     "drum",
+		"drum stab":    "drum",
+		"drum_stab":    "drum",
+		"melodic stab": "melodic",
+		"melodic_stab": "melodic",
+		"oneshot":      "general",
+		"one-shot":     "general",
+		"one_shot":     "general",
+		"hit":          "general",
+		"stab":         "general",
+		"shot":         "general",
+	},
+}
+
+// NormalizeFileName normalizes a filename by applying transformations:
+// - converts to lowercase
+// - replaces spaces with dashes
+// - replaces underscores with dashes
+// - removes consecutive dashes
+// - preserves the file extension
+func NormalizeFileName(fileName string) string {
+	ext := filepath.Ext(fileName)
+	nameWithoutExt := strings.TrimSuffix(fileName, ext)
+
+	// Apply normalization transformations
+	normalized := strings.ToLower(nameWithoutExt)           // lowercase
+	normalized = strings.ReplaceAll(normalized, " ", "-")   // spaces to dashes
+	normalized = strings.ReplaceAll(normalized, "_", "-")   // underscores to dashes
+
+	// Remove consecutive dashes
+	dashRegex := regexp.MustCompile(`-+`)
+	normalized = dashRegex.ReplaceAllString(normalized, "-")
+
+	// Remove leading/trailing dashes
+	normalized = strings.Trim(normalized, "-")
+
+	return normalized + ext
+}
+
+// determineSubcategory checks the filename for subcategory keywords
+// Returns the subcategory based on the longest matching keyword (most specific match)
+func determineSubcategory(category Category, fileName, nameWithoutExt string) string {
+	// Get subcategory map for this category
+	subcatMap, exists := subcategoryKeywords[category]
+	if !exists {
+		return ""
+	}
+
+	// Find all matching keywords and prefer the longest one (most specific)
+	var bestMatch string
+	var bestKeyword string
+	for keyword, subfolder := range subcatMap {
+		if strings.Contains(fileName, keyword) || strings.Contains(nameWithoutExt, keyword) {
+			// Prefer longer keywords (more specific matches)
+			if len(keyword) > len(bestKeyword) {
+				bestKeyword = keyword
+				bestMatch = subfolder
+			}
+		}
+	}
+
+	return bestMatch
+}
+
 // Categorize determines the category of a sample file based on its name
-func Categorize(sample scanner.SampleFile, targetDir string) CategorizedFile {
+func Categorize(sample scanner.SampleFile, targetDir string, normalize bool) CategorizedFile {
 	fileName := strings.ToLower(sample.FileName)
 	nameWithoutExt := strings.ToLower(strings.TrimSuffix(sample.FileName, sample.Extension))
 
 	category := determineCategory(fileName, nameWithoutExt)
-	targetPath := filepath.Join(targetDir, string(category), sample.FileName)
+	subcategory := determineSubcategory(category, fileName, nameWithoutExt)
+
+	// If no subcategory found but category has subcategory support, use "uncategorized"
+	if subcategory == "" && category != CategoryUncategorized {
+		_, hasSubcategories := subcategoryKeywords[category]
+		if hasSubcategories {
+			subcategory = "uncategorized"
+		}
+	}
+
+	// Determine the target filename (with optional normalization)
+	targetFileName := sample.FileName
+	if normalize {
+		targetFileName = NormalizeFileName(sample.FileName)
+	}
+
+	// Build target path with subcategory
+	var targetPath string
+	if subcategory != "" {
+		targetPath = filepath.Join(targetDir, string(category), subcategory, targetFileName)
+	} else {
+		targetPath = filepath.Join(targetDir, string(category), targetFileName)
+	}
 
 	return CategorizedFile{
-		Sample:     sample,
-		Category:   category,
-		TargetPath: targetPath,
+		Sample:      sample,
+		Category:    category,
+		Subcategory: subcategory,
+		TargetPath:  targetPath,
 	}
 }
 
@@ -109,11 +529,11 @@ func determineCategory(fileName, nameWithoutExt string) Category {
 }
 
 // CategorizeBatch categorizes multiple sample files
-func CategorizeBatch(samples []scanner.SampleFile, targetDir string) []CategorizedFile {
+func CategorizeBatch(samples []scanner.SampleFile, targetDir string, normalize bool) []CategorizedFile {
 	categorized := make([]CategorizedFile, 0, len(samples))
 
 	for _, sample := range samples {
-		categorized = append(categorized, Categorize(sample, targetDir))
+		categorized = append(categorized, Categorize(sample, targetDir, normalize))
 	}
 
 	return categorized


### PR DESCRIPTION
This pull request adds support for normalizing filenames during both the preview and apply stages of the sample organization process. Users can now enable normalization via a new `--normalize` flag, which will convert filenames to lowercase and replace spaces and underscores with dashes.

**Flag and CLI improvements:**

* Added a `--normalize` boolean flag to both the `apply` and `preview` commands, allowing users to opt-in to filename normalization. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR153) [[2]](diffhunk://#diff-582c9e90549856426e413aacb6eff1f4faa77d004f68553b39d7b1f4c16d1ddbR110)
* Introduced new variables (`applyNormalizeFilenames` and `normalizeFilenames`) to hold the flag values in `cmd/apply.go` and `cmd/preview.go`. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR19) [[2]](diffhunk://#diff-582c9e90549856426e413aacb6eff1f4faa77d004f68553b39d7b1f4c16d1ddbR17)

**Core logic changes:**

* Updated calls to `categorizer.CategorizeBatch` in both commands to accept the normalization flag, ensuring filenames are processed accordingly. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL72-R73) [[2]](diffhunk://#diff-582c9e90549856426e413aacb6eff1f4faa77d004f68553b39d7b1f4c16d1ddbL55-R56)